### PR TITLE
Use AstroCommunity for adding `nvim-java`

### DIFF
--- a/lua/community.lua
+++ b/lua/community.lua
@@ -1,5 +1,3 @@
-if true then return {} end -- WARN: REMOVE THIS LINE TO ACTIVATE THIS FILE
-
 -- AstroCommunity: import any community modules here
 -- We import this file in `lazy_setup.lua` before the `plugins/` folder.
 -- This guarantees that the specs are processed before any user plugins.
@@ -7,6 +5,7 @@ if true then return {} end -- WARN: REMOVE THIS LINE TO ACTIVATE THIS FILE
 ---@type LazySpec
 return {
   "AstroNvim/astrocommunity",
-  { import = "astrocommunity.pack.lua" },
+  { import = "astrocommunity.pack.java" }, -- add Java language support
+  { import = "astrocommunity.lsp.nvim-java" }, -- opt-in to nvim-java for LSP
   -- import/override with your plugins folder
 }

--- a/lua/plugins/astrolsp.lua
+++ b/lua/plugins/astrolsp.lua
@@ -1,3 +1,5 @@
+if true then return {} end -- WARN: REMOVE THIS LINE TO ACTIVATE THIS FILE
+
 -- AstroLSP allows you to customize the features in AstroNvim's LSP configuration engine
 -- Configuration documentation can be found with `:h astrolsp`
 -- NOTE: We highly recommend setting up the Lua Language Server (`:LspInstall lua_ls`)
@@ -6,7 +8,6 @@
 ---@type LazySpec
 return {
   "AstroNvim/astrolsp",
-  dependencies = { "nvim-java/nvim-java" },
   ---@type AstroLSPOpts
   opts = {
     -- Configuration table of features provided by AstroLSP
@@ -47,15 +48,6 @@ return {
     },
     -- customize how language servers are attached
     handlers = {
-      jdtls = function(_, _)
-        require("java").setup {
-          -- Your custom nvim-java configuration goes here
-        }
-
-        require("lspconfig").jdtls.setup {
-          -- Your custom jdtls settings goes here
-        }
-      end,
       -- a function without a key is simply the default handler, functions take two parameters, the server name and the configured options table for that server
       -- function(server, opts) require("lspconfig")[server].setup(opts) end
 


### PR DESCRIPTION
This moves to adding `nvim-java` through the [AstroCommunity](https://github.com/AstroNvim/astrocommunity) project. By using the Java language pack it automatically sets up things like XML programming language support, Java treesitter, as well as the `nvim-java` support

Awesome to see this template for the project!